### PR TITLE
98_update.pm: Allow reference to another repository

### DIFF
--- a/fhem/FHEM/98_update.pm
+++ b/fhem/FHEM/98_update.pm
@@ -1,5 +1,5 @@
 ################################################################
-# $Id$
+# $Id: 98_update.pm 20600 2019-11-26 18:07:13Z rudolfkoenig $
 
 package main;
 use strict;
@@ -285,7 +285,7 @@ doUpdate($$$$)
   my %lh;
   foreach my $l (@locList) {
     my @l = split(" ", $l, 4);
-    next if($l[0] ne "UPD");
+    next if($l[0] ne "UPD" && $l[0] ne "CRE");
     $lh{$l[3]}{TS} = $l[1];
     $lh{$l[3]}{LEN} = $l[2];
   }
@@ -311,8 +311,10 @@ doUpdate($$$$)
   my $isSingle = ($arg ne "all" && $arg ne "force"  && !$isCheck);
   foreach my $r (@remList) {
     my @r = split(" ", $r, 4);
+    my $cmd = $r[0];
+    next if(!defined($cmd));
 
-    if($r[0] eq "MOV" && ($arg eq "all" || $arg eq "force")) {
+    if($cmd eq "MOV" && ($arg eq "all" || $arg eq "force")) {
       if($r[1] =~ m+\.\.+ || $r[2] =~ m+\.\.+) {
         uLog 1, "Suspicious line $r, aborting";
         return 1;
@@ -322,7 +324,35 @@ doUpdate($$$$)
       uLog 4, "mv $root/$r[1] $root/$r[2]". ($mvret ? " FAILED:$mvret":"");
     }
 
-    next if($r[0] ne "UPD");
+    if($cmd eq "REM" && ($arg eq "all" || $arg eq "force")) {
+      uLog 4, "Processing reference to $r[1]";
+      
+      my $refCtrlFile = upd_getUrl($r[1]); 
+      if($refCtrlFile) {
+        my @refList = split(/\R/, $refCtrlFile);
+        uLog 4, "Got reference $r[1] with ".int(@refList)." entries.";
+        $r[1] =~ /(.*\/)/;
+        my $baseUrl = $1;
+        push(@rl, upd_getChanges($root, $baseUrl)); # Append CHANGED
+        
+        for my $i (0 .. $#refList)
+        {
+        	if ( $refList[$i] =~ /^UPD/)
+        	{
+        		my @l = split(" ", $refList[$i], 4);
+        		$l[3] = $baseUrl . $l[3];
+        		push (@remList,join (" ",@l));
+        	} 
+        }
+	    print join("\n",@remList),"\n";
+        #push (@remList, @refList);
+      }
+    } 
+    if ($cmd eq "LOC") { 
+    	$upd_connecthash{url} = $r[1];
+    }
+
+    next if($cmd ne "UPD" && $cmd ne "CRE");
     my $fName = $r[3];
     my $wouldExcl;
     foreach my $ex (@excl) {
@@ -342,9 +372,10 @@ doUpdate($$$$)
       my $isExcl = (!$isCheck && $wouldExcl);
       my $fPath = "$root/$fName";
       $fPath = $0 if($fPath =~ m/$mainPgm/);
-      my $fileOk = ($lh{$fName} &&
-                    $lh{$fName}{TS} eq $r[1] &&
-                    $lh{$fName}{LEN} eq $r[2]);
+      my $fileOk = ($lh{$fName} &&                  # local files exists and
+                    ($cmd eq "CRE" ||               # either file is create only
+                     ($lh{$fName}{TS} eq $r[1] &&   # or both TS and LEN is same
+                      $lh{$fName}{LEN} eq $r[2]))); # as the remote one
       if($isExcl && !$fileOk) {
         uLog 1, "update: skipping $fName, matches exclude_from_update";
         $nSkipped++;
@@ -356,7 +387,8 @@ doUpdate($$$$)
 
       } else {
         my $sz = -s $fPath;
-        next if($isExcl || ($fileOk && defined($sz) && $sz eq $r[2]));
+        next if($isExcl || 
+                ($fileOk && defined($sz) && ($cmd eq "CRE" || $sz eq $r[2])));
 
       }
     }
@@ -370,11 +402,17 @@ doUpdate($$$$)
     $nChanged++;
     my $sfx = ($arg eq "checktime" ? " $r[1]" : "");
     $sfx =~ s/_.*//;
-    uLog 1, "$r[0] $fName$sfx".
+    uLog 1, "$cmd $fName$sfx".
         ($isCheck && $wouldExcl ? " (excluded from update)" : "");
     next if($isCheck);
 
-    my $remFile = upd_getUrl("$basePath/$fName");
+	my $remFile;
+	if ($fName =~ /^http[s]:\/\//)
+	{
+		$remFile = upd_getUrl($fName);
+    } else {
+	    $remFile = upd_getUrl("$basePath/$fName");
+    }   
     return if(!$remFile); # Error already reported
 
     if(length($remFile) ne $r[2]) {


### PR DESCRIPTION
Implement reference to other repositorys




New command inside controls_<project>.txt fileame
REM  <url>  = Allows a reference to a remote repository / controls file

Demonstration:

`update all https://gist.githubusercontent.com/sidey79/2a21be75275ad999d2522c5a85ddbeef/raw/15e596a74310a455e2a4525fb13fba74dc73eba8/controls_test.txt`


Will Load a controls file which holds a reference to:
https://raw.githubusercontent.com/RFD-FHEM/RFFHEM/master/controls_signalduino.txt

